### PR TITLE
Make table and dbname fully configurable for Postgres producer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+schaufel (0.12) unstable
+ * Table and schema for postgres is now fully configurable
+ * Can set tablename in cli flags for Postgres producer
+
+ -- Chris Travers <ct@onemoredata.com> 17 Feb 2025
+
 schaufel (0.11) unstable; urgency=low
 
   * support for callbacks via metadata (transactional producers) (Closes: #97) 

--- a/Release_Notes.txt
+++ b/Release_Notes.txt
@@ -1,5 +1,8 @@
-1.1 [tbd] Table names are now configurable, and the database name can be
+Schaufel Release Notes
+
+
+0.12      Table names are now configurable, and the database name can be
           specified from the command line.  This requires changes to the
-          configuration and command line format.  See the schaufel.conf.5 man
+          configuration and command line format.  See the schaufel.conf (5) man
           page for more details.  In particular now the "topic" is the fully
           qualified table name.

--- a/Release_Notes.txt
+++ b/Release_Notes.txt
@@ -1,0 +1,5 @@
+1.1 [tbd] Table names are now configurable, and the database name can be
+          specified from the command line.  This requires changes to the
+          configuration and command line format.  See the schaufel.conf.5 man
+          page for more details.  In particular now the "topic" is the fully
+          qualified table name.

--- a/man/schaufel.1
+++ b/man/schaufel.1
@@ -56,6 +56,9 @@ Consumer thread count: 1-n
 .B \-p \fIinteger\fR
 Producer thread count: 1-n
 .TP
+.B \-D \fIdbname\fR
+Database name to connect to (Postgres only)
+.TP
 .B \-b|\-B \fIbrokername\fR
 Broker name/address (kafka consumer/producer only)
 .TP
@@ -110,9 +113,9 @@ As a producer it'll simply write to a topic.
 .SS redis
 As a consumer, schaufel will LPUSH from a list. As a producer it'll BLPOP.
 .SS postgres
-Postgres has no consumer. As a producer schaufel will write messages to a
-table called \fIschema\fR.data. Schema depends on host name, port and topic
-(generation id). The table may only contain a single jsonb tuple. If the
+Postgres has no consumer. As a producer, Schaufel will write to a table where
+the fully qualified table name is the configured producer topic.  The table
+must have only one column which must be able to accept a JSON document. If the
 list of host names contains a semicolon, schaufel will replicate messages
 to the host names listed after the semicolon.
 .SS exports

--- a/man/schaufel.1
+++ b/man/schaufel.1
@@ -115,9 +115,10 @@ As a consumer, schaufel will LPUSH from a list. As a producer it'll BLPOP.
 .SS postgres
 Postgres has no consumer. As a producer, Schaufel will write to a table where
 the fully qualified table name is the configured producer topic.  The table
-must have only one column which must be able to accept a JSON document. If the
-list of host names contains a semicolon, schaufel will replicate messages
-to the host names listed after the semicolon.
+must have only one column which must be able to accept a JSON document (for
+example, a text, json, jsonb, or bytea field). If the list of host names 
+contains a semicolon, schaufel will replicate messages to the host names listed
+after the semicolon.
 .SS exports
 The exporter is also a postgres producer. It has no consumer. It takes a
 json message and dereferences elements (using json pointers) into postgres

--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -129,11 +129,8 @@ producers = (
     {
         type = "postgres";
         threads = 1;
-        # topic and host name are mangled
-        # into the table to be inserted to.
-        # In this case that would be:
-        # bagger_1_5432_test.data
-        topic = "test";
+        # The topic becomes the tablename for ingestion
+        topic = "bagger_1_5432_test.data";
         host = "bagger-1:5432";
     } );
 .RE
@@ -250,16 +247,21 @@ producers = (
     {
         type = "postgres";
         threads = 5;
-        topic = "15";
-        host = "bagger-1:5432,bagger-1:5433,bagger-1:5434;bagger-2:5432,bagger-2:5433,bagger-2:5434";
+        topic = "bagger_1_5432_14.data";
+        host = "bagger-1:5432;bagger-1:5433";
     } );
 .RE
 .PP
 This configuration creates 5 threads per host specified. Hosts are separated
-by commas. Hosts before the semicolon are masters, whereas the others
-receive replicas of messages. Messages are distributed in no particular
-order.
-
+by commas. 
+.PP
+\fBNOTE:\fR  In prior versions, a semicolon was used to differentiate \fImasters\fR 
+from \fIreplicas\fR using a semicolon.  This allowed ordered data to be written
+to two systems independently. The current system is limited to a single master
+and single replica, but future versions will allow multiple replicas.  The topic
+now specifies the ingestion table, while in the past this was generated from
+the host, port, and topic.
+.PP
 .SS exports
 Exports is also a producer to postgres. Unlike bagger, it takes json data
 and dereferences it into columns of a type. At the moment only

--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -256,7 +256,7 @@ This configuration creates 5 threads per host specified. Hosts are separated
 by commas. 
 .PP
 \fBNOTE:\fR  In prior versions, a semicolon was used to differentiate \fImasters\fR 
-from \fIreplicas\fR using a semicolon.  This allowed ordered data to be written
+from \fIreplicas\fR.  This allowed ordered data to be written
 to two systems independently. The current system is limited to a single master
 and single replica, but future versions will allow multiple replicas.  The topic
 now specifies the ingestion table, while in the past this was generated from

--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,7 @@ print_usage()
            "                r : redis\n"
            "-c      : consumer_threads\n"
            "-p      : producer_threads\n"
+           "-D      : producer_dbname\n"
            "-b | -B : consumer / producer broker (only kafka)\n"
            "-g | -G : consumer / producer groupid (only kafka)\n"
            "-h | -H : consumer / producer host (redis,postgres,exports)\n"
@@ -272,7 +273,7 @@ main(int argc, char **argv)
     config_t config;
     config_init(&config);
 
-    while ((opt = getopt(argc, argv, "l:i:o:c:p:b:h:g:t:f:s:B:C:H:G:T:F:S:V")) != -1)
+    while ((opt = getopt(argc, argv, "l:i:o:c:p:D:b:h:g:t:f:s:B:C:H:G:T:F:S:V")) != -1)
     {
         switch (opt)
         {
@@ -292,6 +293,9 @@ main(int argc, char **argv)
             case 'p':
                 producer_threads += atoi(optarg);
                 o.producer_threads = producer_threads;
+                break;
+            case 'D':
+                o.out_dbname = optarg;
                 break;
             case 'b':
                 o.in_broker = optarg;

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -24,7 +24,7 @@ struct pg_parameters {
     const char     *dbname;
     const char     *user;
     const char     *host_replica;
-    const char     *generation;
+    const char     *table;
     postgres_format fmt;
 };
 
@@ -54,7 +54,7 @@ _connectinfo(const char *host, const char *dbname, const char *user)
 }
 
 static char *
-_cpycmd(const char *host, const char *generation, postgres_format fmt)
+_cpycmd(const char *host, const char *table, postgres_format fmt)
 {
     const char *format;
     char       *cpycmd;
@@ -92,9 +92,9 @@ _cpycmd(const char *host, const char *generation, postgres_format fmt)
     int ret;
     
     char *cpyfmt = "COPY %s FROM STDIN (FORMAT %s)";
-    int len = strlen(cpyfmt) + strlen(generation) + strlen(format) + 20;
+    int len = strlen(cpyfmt) + strlen(table) + strlen(format) + 20;
     cpycmd = SCALLOC(len, 1);
-    ret = snprintf(cpycmd, len, cpyfmt, generation, format);
+    ret = snprintf(cpycmd, len, cpyfmt, table, format);
    
     if (ret < 0)
     {
@@ -124,7 +124,7 @@ read_pg_params(struct pg_parameters *p, config_setting_t *config)
     config_setting_lookup_string(config, "dbname", &p->dbname);
     config_setting_lookup_string(config, "user", &p->user);
     config_setting_lookup_string(config, "replica", &p->host_replica);
-    config_setting_lookup_string(config, "topic", &p->generation);
+    config_setting_lookup_string(config, "topic", &p->table);
     config_setting_lookup_string(config, "format", &format);
 
     assert(format != NULL);
@@ -146,7 +146,7 @@ postgres_meta_init(struct pg_parameters *p)
 {
     Meta m = SCALLOC(1, sizeof(*m));
 
-    m->cpycmd = _cpycmd(p->host, p->generation, p->fmt);
+    m->cpycmd = _cpycmd(p->host, p->table, p->fmt);
     m->conninfo = _connectinfo(p->host, p->dbname, p->user);
     m->cpyfmt = (int) p->fmt;
 
@@ -399,7 +399,7 @@ postgres_validate(config_setting_t *config)
             __FILE__, __LINE__, replicas);
         ret = false;
     }
-    if(!CONF_L_IS_STRING(config, "topic", &topic, "need a topic/generation!"))
+    if(!CONF_L_IS_STRING(config, "topic", &topic, "need a topic/table!"))
         ret = false;
     if(!ret) goto error;
 

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -90,21 +90,12 @@ _cpycmd(const char *host, const char *generation, postgres_format fmt)
     }
 
     int ret;
-    if (fmt == POSTGRES_CSV || fmt == POSTGRES_BINARY)
-    {
-        char *fmt = "COPY %s FROM STDIN (FORMAT %s)";
-        int len = strlen(fmt) + strlen(generation) + strlen(format) + 20;
-        cpycmd = SCALLOC(len, 1);
-        ret = snprintf(cpycmd, len, fmt, generation, format);
-    }
-    else
-    {
-        char *fmt = "COPY %s_%d_%s.data FROM STDIN (FORMAT %s)";
-        int len = strlen(fmt) + strlen(hostname) + strlen(generation) + strlen(format) + 20;
-        cpycmd = SCALLOC(len, 1);
-        ret = snprintf(cpycmd, len, fmt, hostname, port, generation, format);
-    }
-
+    
+    char *cpyfmt = "COPY %s FROM STDIN (FORMAT %s)";
+    int len = strlen(cpyfmt) + strlen(generation) + strlen(format) + 20;
+    cpycmd = SCALLOC(len, 1);
+    ret = snprintf(cpycmd, len, cpyfmt, generation, format);
+   
     if (ret < 0)
     {
         logger_log("%s %d: error while formatting COPY query string",

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -238,6 +238,7 @@ postgres_producer_produce(Producer p, Message msg)
         return;
     }
 
+    // Note this is being moved to the Postgres side'd responsibility. 
     if (m->cpyfmt != POSTGRES_BINARY)
     {
         char *s = strstr(buf, "\\u0000");

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -325,6 +325,10 @@ config_merge(config_t* config, Options o)
             setting = _add_member(parent, "host", CONFIG_TYPE_STRING);
             config_setting_set_string(setting, o.out_host);
         }
+        if (o.out_dbname) {
+            setting = _add_member(parent, "dbname", CONFIG_TYPE_STRING);
+            config_setting_set_string(setting, o.out_dbname);
+        }
         if (o.out_groupid) {
             setting = _add_member(parent, "groupid", CONFIG_TYPE_STRING);
             config_setting_set_string(setting, o.out_groupid);

--- a/src/utils/options.h
+++ b/src/utils/options.h
@@ -23,6 +23,7 @@ typedef struct Options {
     char *out_file;
     char *out_groupid;
     char *out_topic;
+    char *out_dbname;
     char *logger;
     Array in_hosts;
     Array out_hosts;


### PR DESCRIPTION
The dbname has always been able to be set in the config file, but here we add an ability to set it via the command line.

A more significant change involves the handling of the ingestion table.  Traditionally for Bagger, the table has been hardcoded as "data" and in a schema that includes the initial hostname, port number, and a numeric generation id.  Here we change this to be manually specified for the schema and table name.

A secondary issue here is that this removes the possibility of having multiple pairs of bagger dbs filled by one schaufel.

As a result this is not backwards compatible with previous versions.  The configuration must be changed and in some (rare) cases, several schaufel instances might need to take the place of one in the previous configuration.  On the other hand, it is the first step to being able to have a replication factor greater than 2.