### PR TITLE
Fixes #11

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -62,6 +62,9 @@ file_producer_produce(Producer p, Message msg)
     size_t ret;
 
     ret = fwrite(line, len, nmemb, ((Meta) p->meta)->fp);
+
+    /* have to add newline back to separate records. */
+    ret += fwrite("\n", (size_t) 1, (size_t) 1,((Meta) p->meta)->fp);
     if (ret < nmemb) {
         logger_log("%s %d: %s", __FILE__, __LINE__, strerror(errno));
         abort();
@@ -97,6 +100,7 @@ file_consumer_consume(Consumer c, Message msg)
     size_t  bufsize = 0;
     ssize_t read;
     int8_t err = errno;
+    size_t len;
     errno = 0;
     if ((read = getline(&line, &bufsize, ((Meta) c->meta)->fp)) == -1)
     {
@@ -114,8 +118,14 @@ file_consumer_consume(Consumer c, Message msg)
         return -1;
     }
     errno = err;
+
+    /* the newline has to be stripped because it can be misinterpreted by
+     * other producers.
+     */
+    len = strcspn(line, "\n"); 
+    line[len] =  '\0';
     message_set_data(msg, line);
-    message_set_len(msg, (size_t) read);
+    message_set_len(msg, len);
     return 0;
 }
 


### PR DESCRIPTION
This patch changes the file consumer so that it strips trailing newlines.

Without this change, newlines get interpolated into Postgres loads leading to lots of invalid json documents (every other document is ).  With this change the file consumer strips out that newline and the producer adds a newline after every message so it is still round trip safe.

Manual tests run include sending one file (with a trailing newline) to another file and making sure the md5 sums match, and then (in a branch which also included #10) loading the file into Postgres and noting that the empty strings were not loaded.

This fixes #11 