### PR TITLE
src/hooks/chomp.c: a hook to chomp IFS off of strings

### DIFF
--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -521,6 +521,11 @@ producers = ( {
 );
 .RE
 
+.SS chomp
+\fBchomp\fR chops off all inter field separators from the end of a string.
+It is inspired by perls chomp() function.
+.PP
+
 .SS PLEASE CONTRIBUTE
 .PP
 As always, feel free to implement more of what you need.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = schaufel
 schaufel_SOURCES = \
 	dummy.c main.c queue.c exports.c hooks.c postgres.c validator.c consumer.c \
 	redis.c file.c kafka.c producer.c \
-	hooks/dummy.c hooks/jsonexport.c hooks/xmark.c \
+	hooks/dummy.c hooks/jsonexport.c hooks/xmark.c hooks/chomp.c \
 	utils/array.c utils/fnv.c utils/metadata.c utils/strlwr.c utils/bintree.c \
 	utils/helper.c utils/postgres.c utils/config.c utils/logger.c utils/scalloc.c \
 	utils/htable.c

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -7,6 +7,7 @@
 #include "hooks/dummy.h"
 #include "hooks/xmark.h"
 #include "hooks/jsonexport.h"
+#include "hooks/chomp.h"
 
 typedef struct hooklist {
     uint64_t num;
@@ -38,21 +39,19 @@ static Hptr _find_hook(const char *name)
 void hooks_register()
 {
     /* todo:  dynamic module adding */
-    struct hptr dummy =
-        {"dummy",&h_dummy,&h_dummy_init,&h_dummy_validate,&h_dummy_free,NULL};
-    struct hptr xmark =
-        {"xmark",&h_xmark,&h_xmark_init,&h_xmark_validate,&h_xmark_free,NULL};
-    struct hptr jsonexport =
-        {"jsonexport",&h_jsonexport,&h_jsonexport_init,&h_jsonexport_validate,&h_jsonexport_free,NULL};
+    struct hptr hptrs[] = {
+        {"dummy",&h_dummy,&h_dummy_init,&h_dummy_validate,&h_dummy_free,NULL},
+        {"xmark",&h_xmark,&h_xmark_init,&h_xmark_validate,&h_xmark_free,NULL},
+        {"jsonexport",&h_jsonexport,&h_jsonexport_init,&h_jsonexport_validate,&h_jsonexport_free,NULL},
+        {"chomp",&h_chomp,&h_chomp_init,&h_chomp_validate,&h_chomp_free,NULL},
+        {"", NULL, NULL, NULL, NULL} /* terminator */
+    };
 
-    hooks_available = SCALLOC(4,sizeof(struct hptr)); // null terminator
+    /* dynamic allocation for architectural reasons. This list might change on
+     * reload in the future */
+    hooks_available = SCALLOC(sizeof(hptrs),sizeof(struct hptr));
 
-    memcpy(hooks_available,(void *) &dummy,
-        sizeof(struct hptr));
-    memcpy(hooks_available+1,(void *) &xmark,
-        sizeof(struct hptr));
-    memcpy(hooks_available+2,(void *) &jsonexport,
-        sizeof(struct hptr));
+    memcpy(hooks_available, hptrs, sizeof(hooks_available) * sizeof(struct hptr));
 
     return;
 }
@@ -95,6 +94,7 @@ inline bool hooklist_run(Hooklist h, Message msg)
  *      call each validator of all hooks registered
  */
 bool hooks_validate(config_setting_t *conf)
+
 {
     bool res = true;
 

--- a/src/hooks.h
+++ b/src/hooks.h
@@ -21,13 +21,13 @@ typedef struct hptr {
 } *Hptr;
 
 typedef struct hooklist *Hooklist;
-Hooklist hook_init();
+Hooklist hook_init(void);
 
 void hooks_add(Hooklist hooks, config_setting_t *conf);
 void hook_free(Hooklist hooks);
-void hooks_register();
-void hooks_deregister();
-bool hooklist_run();
+void hooks_register(void);
+void hooks_deregister(void);
+bool hooklist_run(Hooklist, Message);
 bool hooks_validate(config_setting_t *conf);
 
 #endif

--- a/src/hooks/chomp.c
+++ b/src/hooks/chomp.c
@@ -1,0 +1,49 @@
+#include "utils/config.h"
+#include "utils/scalloc.h"
+#include "utils/helper.h"
+#include "queue.h"
+// This header contains the public api used to initialise this hook
+#include "hooks/chomp.h"
+
+
+// h_chomp removes trailing field separators (see perldoc chomp)
+bool h_chomp(UNUSED Context ctx, Message msg)
+{
+    // TODO: Consider marking messages as strings/blobs.
+    // TODO: this is utf-8/ASCII. Consider storing encodings.
+    size_t len = message_get_len(msg);
+    char *data = message_get_data(msg);
+
+    // all ascii chars < 16 are control characters
+    while (len > 0 && ((data[len-1] | 0xf) == 0xf || data[len-1] == ' '))
+        len--;
+
+    data[len] = '\0';
+    message_set_len(msg, len);
+
+    // Technically message data is a pointer, so we don't have to set it,
+    // but if we ever not zero-copy, this would be correct.
+    message_set_data(msg, data);
+
+    end:
+    return true;
+}
+
+Context h_chomp_init(UNUSED config_setting_t *config)
+{
+    Context ctx = SCALLOC(0,sizeof(*ctx));
+    return ctx;
+}
+
+// chomp takes no configurables
+bool h_chomp_validate(UNUSED config_setting_t *config)
+{
+    return true;
+}
+
+void h_chomp_free(Context ctx)
+{
+    free(ctx);
+    return;
+}
+

--- a/src/hooks/chomp.h
+++ b/src/hooks/chomp.h
@@ -1,0 +1,12 @@
+#ifndef _SCHAUFEL_HOOK_CHOMP_H_
+#define _SCHAUFEL_HOOK_CHOMP_H_
+
+#include "hooks.h"
+#include "utils/config.h"
+
+bool    h_chomp(Context ctx, Message msg);
+Context h_chomp_init(config_setting_t *config);
+bool    h_chomp_validate(config_setting_t *config);
+void    h_chomp_free(Context ctx);
+
+#endif

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,14 +1,14 @@
 check_PROGRAMS = dummy_consumer_test jsonexports_test parse_hostinfo array \
 		dummy_producer_test logger_test queue_test bintree_test \
 		file_consumer_test logparse_test strlwr_test config_merge_test \
-		fnv_test metadata_test config_test hooks_test parse_connstring \
+		fnv_test metadata_test config_test hooks_test hook_chomp_test parse_connstring \
 		htable_test kafka_validator
 
 TESTS = $(check_PROGRAMS)
 
 test : check-am
 
-common_sources = $(top_builddir)/src/utils/config.c $(top_builddir)/src/queue.c $(top_builddir)/src/consumer.c $(top_builddir)/src/producer.c $(top_builddir)/src/hooks.c $(top_builddir)/src/validator.c $(top_builddir)/src/utils/logger.c $(top_builddir)/src/utils/scalloc.c $(top_builddir)/src/hooks/dummy.c $(top_builddir)/src/hooks/xmark.c $(top_builddir)/src/hooks/jsonexport.c $(top_builddir)/src/utils/metadata.c $(top_builddir)/src/utils/fnv.c $(top_builddir)/src/utils/bintree.c $(top_builddir)/src/file.c $(top_builddir)/src/exports.c $(top_builddir)/src/postgres.c $(top_builddir)/src/redis.c $(top_builddir)/src/kafka.c $(top_builddir)/src/utils/helper.c $(top_builddir)/src/utils/array.c $(top_builddir)/src/utils/postgres.c $(top_builddir)/src/dummy.c $(top_builddir)/src/utils/strlwr.c $(top_builddir)/src/utils/htable.c
+common_sources = $(top_builddir)/src/utils/config.c $(top_builddir)/src/queue.c $(top_builddir)/src/consumer.c $(top_builddir)/src/producer.c $(top_builddir)/src/hooks.c $(top_builddir)/src/validator.c $(top_builddir)/src/utils/logger.c $(top_builddir)/src/utils/scalloc.c $(top_builddir)/src/hooks/dummy.c $(top_builddir)/src/hooks/xmark.c $(top_builddir)/src/hooks/chomp.c $(top_builddir)/src/hooks/jsonexport.c $(top_builddir)/src/utils/metadata.c $(top_builddir)/src/utils/fnv.c $(top_builddir)/src/utils/bintree.c $(top_builddir)/src/file.c $(top_builddir)/src/exports.c $(top_builddir)/src/postgres.c $(top_builddir)/src/redis.c $(top_builddir)/src/kafka.c $(top_builddir)/src/utils/helper.c $(top_builddir)/src/utils/array.c $(top_builddir)/src/utils/postgres.c $(top_builddir)/src/dummy.c $(top_builddir)/src/utils/strlwr.c $(top_builddir)/src/utils/htable.c
 
 dummy_consumer_test_SOURCES = $(common_sources) dummy_consumer_test.c
 dummy_producer_test_SOURCES = $(common_sources) jsonexports_test.c
@@ -26,6 +26,7 @@ strlwr_test_SOURCES = $(common_sources) strlwr_test.c
 fnv_test_SOURCES = $(common_sources) fnv_test.c
 metadata_test_SOURCES = $(common_sources) metadata_test.c
 hooks_test_SOURCES = $(common_sources) hooks_test.c
+hook_chomp_test_SOURCES = $(common_sources) hook_chomp_test.c
 parse_connstring_SOURCES = $(common_sources) parse_connstring.c
 htable_test_SOURCES = $(common_sources) htable_test.c
 kafka_validator_SOURCES = $(common_sources) kafka_validator.c

--- a/t/hook_chomp_test.c
+++ b/t/hook_chomp_test.c
@@ -1,0 +1,62 @@
+#include "schaufel.h"
+#include "test/test.h"
+#include "hooks.h"
+#include "queue.h"
+#include <string.h>
+
+int main(void)
+{
+    int res = 0;
+    config_t root;
+    bool rv = true;
+    size_t len = 0;
+    config_setting_t *hook_conf = NULL;
+    config_init(&root);
+    res = config_read_string(&root, "hooks = ({ type = \"chomp\"; });");
+    pretty_assert(res == CONFIG_TRUE);
+    hook_conf = config_lookup(&root,"hooks");
+
+    // test finding a hook
+    hooks_register();
+    pretty_assert(hooks_validate(hook_conf) == true);
+
+    Hooklist test = hook_init();
+    hooks_add(test,hook_conf);
+
+    Message msg = message_init();
+    message_set_data(msg,strdup("hurz\n"));
+    message_set_len(msg,5);
+    pretty_assert((rv = hooklist_run(test,msg)) == true);
+    pretty_assert((res = strcmp(message_get_data(msg),"hurz")) == 0);
+    pretty_assert((len = message_get_len(msg)) == 4);
+    res |= (len != 4) || !rv;
+
+    message_set_data(msg,strdup("hurz\n\n\v\r\n"));
+    message_set_len(msg,9);
+    pretty_assert((rv = hooklist_run(test,msg)) == true);
+    pretty_assert((res |= strcmp(message_get_data(msg),"hurz")) == 0);
+    pretty_assert((len = message_get_len(msg)) == 4);
+    res |= (len != 4) | !rv;
+
+    message_set_data(msg,strdup(""));
+    message_set_len(msg,0);
+    pretty_assert((rv = hooklist_run(test,msg)) == true);
+    pretty_assert((res |= strcmp(message_get_data(msg),"")) == 0);
+    pretty_assert((len = message_get_len(msg)) == 0);
+    res |= (len != 0) || !rv;
+
+    message_set_data(msg,strdup("       "));
+    message_set_len(msg,7);
+    pretty_assert((rv = hooklist_run(test,msg)) == true);
+    pretty_assert((res |= strcmp(message_get_data(msg),"")) == 0);
+    pretty_assert((len = message_get_len(msg)) == 0);
+    res |= (len != 0) || !rv;
+
+    free(msg);
+    hook_free(test);
+    hooks_deregister();
+
+    config_destroy(&root);
+
+    return res != 0;
+}


### PR DESCRIPTION
An alternative solution to #11.

This PR implements a hook that can chop from any message if so required, making it universal to all consumers/producers.
I haven't thoroughly tested this, but I've overexerted myself as is with this. Feel free to patch it up any way you like and merge.